### PR TITLE
chore: harden biome lint rules

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
-pnpm lint
+pnpm check
+git add -A
 pnpm astro check

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "astro/config";
-import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "astro/config";
 
 export default defineConfig({
   output: "static",

--- a/biome.json
+++ b/biome.json
@@ -13,6 +13,10 @@
       "recommended": true,
       "complexity": {
         "noImportantStyles": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error"
       }
     }
   },
@@ -36,6 +40,17 @@
       "css": {
         "parser": {
           "cssModules": false
+        }
+      }
+    },
+    {
+      "includes": ["**/*.astro"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedImports": "off",
+            "noUnusedVariables": "off"
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "astro": "astro",
     "lint": "biome lint .",
     "format": "biome format --write .",
+    "check": "biome check --write .",
     "prepare": "husky"
   },
   "dependencies": {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,6 +1,6 @@
 ---
-import sharp from "sharp";
 import { join } from "node:path";
+import sharp from "sharp";
 
 const CHARS = "<>{}[]()#.,:;=+-*/|&@!?%$\"'`~^_";
 const WIDTH = 60;

--- a/src/data/experiences.ts
+++ b/src/data/experiences.ts
@@ -1,50 +1,51 @@
 export interface Experience {
-  title: string
-  company: string
-  period: string
-  description: string
+  title: string;
+  company: string;
+  period: string;
+  description: string;
 }
 
-export const experiences: Experience[] = [{
-  title: 'Freelance Web Developer',
-  company: 'Independent',
-  period: 'Jan 2020 — Present',
-  description:
-    'Building websites, web applications, and custom growth tools for ambitious teams. Clients across France and internationally.',
-},
-{
-  title: 'Marketing Software Engineer',
-  company: 'Swile',
-  period: 'Jan 2022 — Present',
-  description:
-    'Build durable and scalable acquisition systems leveraging marketing team efforts.',
-},
-{
-  title: 'Co-Founder',
-  company: 'Synergia',
-  period: 'Oct 2024 — Jun 2025',
-  description:
-    'Co-founded an AI automation agency based in Dubai. Built and delivered custom AI-based automation solutions for clients in sports, healthcare and high luxury services.',
-},
-{
-  title: 'Co-Founder',
-  company: 'Hero-Com',
-  period: 'Sept 2019 — Dec 2019',
-  description:
-    'E-commerce startup, team of 2. Learned Facebook/Google Ads, conversion optimisation, and supply-chain logistics. Shut down after four months due to an unsustainable burn rate.',
-},
-{
-  title: 'Co-Founder',
-  company: 'HeroGrowth',
-  period: 'Feb 2019 — Sept 2019',
-  description:
-    'Social media management agency focused on sports car and luxury brands. Managed sales, client relationships, and a team of 3 freelancers while building growth hacking tools for delivery.',
-},
-{
-  title: 'IP Support Consultant',
-  company: 'Questel',
-  period: 'Sept 2016 — Aug 2018',
-  description:
-    'Started in customer support, quickly evolved to user training and project management. Technical support for Orbit Intelligence, user training, and acting as interface between technical teams and sales reps.',
-},
-]
+export const experiences: Experience[] = [
+  {
+    title: "Freelance Web Developer",
+    company: "Independent",
+    period: "Jan 2020 — Present",
+    description:
+      "Building websites, web applications, and custom growth tools for ambitious teams. Clients across France and internationally.",
+  },
+  {
+    title: "Marketing Software Engineer",
+    company: "Swile",
+    period: "Jan 2022 — Present",
+    description:
+      "Build durable and scalable acquisition systems leveraging marketing team efforts.",
+  },
+  {
+    title: "Co-Founder",
+    company: "Synergia",
+    period: "Oct 2024 — Jun 2025",
+    description:
+      "Co-founded an AI automation agency based in Dubai. Built and delivered custom AI-based automation solutions for clients in sports, healthcare and high luxury services.",
+  },
+  {
+    title: "Co-Founder",
+    company: "Hero-Com",
+    period: "Sept 2019 — Dec 2019",
+    description:
+      "E-commerce startup, team of 2. Learned Facebook/Google Ads, conversion optimisation, and supply-chain logistics. Shut down after four months due to an unsustainable burn rate.",
+  },
+  {
+    title: "Co-Founder",
+    company: "HeroGrowth",
+    period: "Feb 2019 — Sept 2019",
+    description:
+      "Social media management agency focused on sports car and luxury brands. Managed sales, client relationships, and a team of 3 freelancers while building growth hacking tools for delivery.",
+  },
+  {
+    title: "IP Support Consultant",
+    company: "Questel",
+    period: "Sept 2016 — Aug 2018",
+    description:
+      "Started in customer support, quickly evolved to user training and project management. Technical support for Orbit Intelligence, user training, and acting as interface between technical teams and sales reps.",
+  },
+];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -53,5 +53,4 @@ export const projects: Project[] = [
     url: "https://mystudiz.com/",
     github: "https://github.com/Raigato/myStudizApp",
   },
-
 ];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,13 @@
 ---
 import "../styles/global.css";
-import Navbar from "../components/Navbar.astro";
-import Hero from "../components/Hero.astro";
 import About from "../components/About.astro";
-import Experience from "../components/Experience.astro";
-import Projects from "../components/Projects.astro";
 import Contact from "../components/Contact.astro";
-import Footer from "../components/Footer.astro";
 import Cursor from "../components/Cursor.astro";
+import Experience from "../components/Experience.astro";
+import Footer from "../components/Footer.astro";
+import Hero from "../components/Hero.astro";
+import Navbar from "../components/Navbar.astro";
+import Projects from "../components/Projects.astro";
 import PostHog from "../components/posthog.astro";
 ---
 


### PR DESCRIPTION
## Summary
- Explicitly set `noUnusedVariables` and `noUnusedImports` to `"error"` severity in biome.json (previously relied on default warn level)
- Added `**/*.astro` override to disable those rules for Astro files — Biome can't detect imports used in Astro's template section, causing false positives on all component imports
- Added `check` script (`biome check --write .`) to package.json for auto-fix in one command
- Updated pre-commit hook: replaced `pnpm lint` with `pnpm check` + `git add -A` so auto-formatting changes are re-staged before the commit
- Remaining formatting fixes (import order, semicolons, trailing newlines) applied by `biome check --write` on existing files