### PR TITLE
fix: scope pre-commit git add to already-staged files only

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
 pnpm check
-git add -A
+git diff --cached --name-only --diff-filter=d | xargs git add --
 pnpm astro check


### PR DESCRIPTION
## Summary
- `git add -A` in the pre-commit hook would stage **all** working directory changes after `biome check --write` auto-fixes, silently including unrelated in-progress work in the commit
- Replaced with `git diff --cached --name-only --diff-filter=d | xargs git add --` to re-stage only the files that were already staged at commit time, so biome's auto-fixes are captured without pulling in anything else