### PR TITLE
fix: reduce typewriter animation speed in hero

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -151,9 +151,9 @@ const colorData = JSON.stringify(colorRows);
           clearInterval(interval);
           finalize();
           cursor.style.display = "none";
-          setTimeout(resolve, 200);
+          setTimeout(resolve, 100);
         }
-      }, 60);
+      }, 30);
     });
   }
 


### PR DESCRIPTION
## Summary
- Halve the per-character typing interval from 60ms to 30ms
- Halve the pause between lines from 200ms to 100ms
- Makes the terminal intro feel snappier on page load