### PR TITLE
a11y: semantic HTML, WCAG AA contrast fixes, and Playwright axe audit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,35 @@ jobs:
         with:
           path: dist
 
+  e2e:
+    name: E2E Accessibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: pnpm test:e2e
+
   deploy:
     name: Deploy
-    needs: build
+    needs: [build, e2e]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ pnpm-debug.log*
 # jetbrains setting folder
 .idea/
 
+# playwright
+playwright-report/
+test-results/
+
 # project-local tool dirs
 .obsidian/
 .vscode/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm test:e2e

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "files": {
-    "includes": ["src/**", "scripts/**", "*.ts", "*.json", "!biome.json"]
+    "includes": [
+      "src/**",
+      "e2e/**",
+      "scripts/**",
+      "*.ts",
+      "*.json",
+      "!biome.json"
+    ]
   },
   "assist": {
     "enabled": true,

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,25 @@
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+
+test.describe("Accessibility", () => {
+  test("homepage has no axe-core violations", async ({ page }) => {
+    await page.goto("/");
+
+    // Wait for the page to be fully rendered
+    await page.waitForLoadState("networkidle");
+
+    const results = await new AxeBuilder({ page }).analyze();
+
+    if (results.violations.length > 0) {
+      const report = results.violations
+        .map(
+          (v) =>
+            `[${v.impact}] ${v.id}: ${v.description}\n  Nodes: ${v.nodes.map((n) => n.html).join(", ")}`,
+        )
+        .join("\n\n");
+      console.error("Axe violations:\n" + report);
+    }
+
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -4,9 +4,27 @@ import { expect, test } from "@playwright/test";
 test.describe("Accessibility", () => {
   test("homepage has no axe-core violations", async ({ page }) => {
     await page.goto("/");
-
-    // Wait for the page to be fully rendered
     await page.waitForLoadState("networkidle");
+
+    // Scroll through the full page so scroll-triggered sections are rendered
+    await page.evaluate(async () => {
+      await new Promise<void>((resolve) => {
+        const distance = 300;
+        const delay = 100;
+        const timer = setInterval(() => {
+          window.scrollBy(0, distance);
+          if (
+            window.scrollY + window.innerHeight >=
+            document.body.scrollHeight
+          ) {
+            clearInterval(timer);
+            window.scrollTo(0, 0);
+            resolve();
+          }
+        }, delay);
+      });
+    });
+    await page.waitForTimeout(500);
 
     const results = await new AxeBuilder({ page }).analyze();
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check --write .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"
   },
   "dependencies": {
@@ -25,7 +27,9 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.1",
     "@biomejs/biome": "^2.4.8",
+    "@playwright/test": "^1.58.2",
     "@types/node": "^25.5.0",
     "husky": "^9.1.7",
     "sharp": "^0.34.5"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "html",
+  use: {
+    baseURL: "http://localhost:4321",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:4321",
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,15 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.11.1
+        version: 4.11.1(playwright-core@1.58.2)
       '@biomejs/biome':
         specifier: ^2.4.8
         version: 2.4.8
+      '@playwright/test':
+        specifier: ^1.58.2
+        version: 1.58.2
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
@@ -88,6 +94,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
+
+  '@axe-core/playwright@4.11.1':
+    resolution: {integrity: sha512-mKEfoUIB1MkVTht0BGZFXtSAEKXMJoDkyV5YZ9jbBmZCcWDz71tegNsdTkIN8zc/yMi5Gm2kx7Z5YQ9PfWNAWw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -505,6 +516,11 @@ packages:
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
 
+  '@playwright/test@1.58.2':
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -860,6 +876,10 @@ packages:
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
+  axe-core@4.11.1:
+    resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
+    engines: {node: '>=4'}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1073,6 +1093,11 @@ packages:
   fontkitten@1.0.3:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1487,6 +1512,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -2100,6 +2135,11 @@ snapshots:
     dependencies:
       yaml: 2.8.3
 
+  '@axe-core/playwright@4.11.1(playwright-core@1.58.2)':
+    dependencies:
+      axe-core: 4.11.1
+      playwright-core: 1.58.2
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -2383,6 +2423,10 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@playwright/test@1.58.2':
+    dependencies:
+      playwright: 1.58.2
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.1)':
     dependencies:
@@ -2785,6 +2829,8 @@ snapshots:
       - uploadthing
       - yaml
 
+  axe-core@4.11.1: {}
+
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
@@ -2981,6 +3027,9 @@ snapshots:
   fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3587,6 +3636,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.8:
     dependencies:

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -13,11 +13,11 @@ import { config } from "../data/config";
       </div>
       <div>
         <h3 class="font-mono text-xs text-white/35 tracking-[3px] uppercase mb-4">Stack</h3>
-        <div class="grid grid-cols-2 gap-2">
+        <ul class="grid grid-cols-2 gap-2 list-none p-0 m-0">
           {config.stack.map((item) => (
-            <span class="font-mono text-xs border border-[#242424] text-white/50 px-3 py-1.5 tracking-wider">{item}</span>
+            <li class="font-mono text-xs border border-[#242424] text-white/50 px-3 py-1.5 tracking-wider">{item}</li>
           ))}
-        </div>
+        </ul>
       </div>
     </div>
   </div>

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -3,16 +3,16 @@ import { config } from "../data/config";
 ---
 <section id="about" aria-label="About" class="py-24 px-6 border-t border-[#1e1e1e]">
   <div class="max-w-6xl mx-auto">
-    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
-      <h2 class="font-mono text-xs text-white/25 tracking-widest">// ABOUT</h2><span>02 / 06</span>
+    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/50 tracking-widest">
+      <h2 class="font-mono text-xs text-white/50 tracking-widest">// ABOUT</h2><span>02 / 06</span>
     </div>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-12">
       <div>
-        <h3 class="font-mono text-xs text-white/35 tracking-[3px] uppercase mb-4">Bio</h3>
+        <h3 class="font-mono text-xs text-white/50 tracking-[3px] uppercase mb-4">Bio</h3>
         <p class="text-white/70 leading-relaxed text-sm">{config.bio}</p>
       </div>
       <div>
-        <h3 class="font-mono text-xs text-white/35 tracking-[3px] uppercase mb-4">Stack</h3>
+        <h3 class="font-mono text-xs text-white/50 tracking-[3px] uppercase mb-4">Stack</h3>
         <ul class="grid grid-cols-2 gap-2 list-none p-0 m-0">
           {config.stack.map((item) => (
             <li class="font-mono text-xs border border-[#242424] text-white/50 px-3 py-1.5 tracking-wider">{item}</li>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -4,7 +4,7 @@ import { config } from "../data/config";
 
 <section id="contact" aria-label="Contact" class="py-24 px-6 border-t border-[#1e1e1e]">
   <div class="max-w-6xl mx-auto">
-    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
+    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/50 tracking-widest">
       <span>// CONTACT</span><span>06 / 06</span>
     </div>
     <h2 class="text-6xl font-black tracking-tight leading-none mb-12 uppercase">

--- a/src/components/Cursor.astro
+++ b/src/components/Cursor.astro
@@ -1,5 +1,5 @@
-<div id="cursor-dot"></div>
-<div id="cursor-ring"></div>
+<div id="cursor-dot" aria-hidden="true"></div>
+<div id="cursor-ring" aria-hidden="true"></div>
 
 <style>
   #cursor-dot {

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -7,17 +7,19 @@ import { experiences } from "../data/experiences";
     <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
       <h2 class="font-mono text-xs text-white/25 tracking-widest">// EXPERIENCE</h2><span>04 / 06</span>
     </div>
-    <div id="experience-list" class="flex flex-col divide-y divide-[#1e1e1e]">
+    <ol id="experience-list" class="list-none p-0 m-0 flex flex-col divide-y divide-[#1e1e1e]">
       {experiences.map((exp) => (
-        <article class="experience-item py-8">
-          <h3 class="font-mono text-sm font-bold text-white mb-1 tracking-tight">{exp.title}</h3>
-          <p class="font-mono text-xs text-white/25 tracking-widest uppercase mb-3">
-            {exp.company} · {exp.period}
-          </p>
-          <p class="text-sm text-white/50 leading-relaxed">{exp.description}</p>
-        </article>
+        <li class="list-none">
+          <article class="experience-item py-8">
+            <h3 class="font-mono text-sm font-bold text-white mb-1 tracking-tight">{exp.title}</h3>
+            <p class="font-mono text-xs text-white/25 tracking-widest uppercase mb-3">
+              {exp.company} · {exp.period}
+            </p>
+            <p class="text-sm text-white/50 leading-relaxed">{exp.description}</p>
+          </article>
+        </li>
       ))}
-    </div>
+    </ol>
   </div>
 </section>
 

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -4,15 +4,15 @@ import { experiences } from "../data/experiences";
 
 <section id="experience" aria-label="Experience" class="py-24 px-6 border-t border-[#1e1e1e]">
   <div class="max-w-6xl mx-auto">
-    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
-      <h2 class="font-mono text-xs text-white/25 tracking-widest">// EXPERIENCE</h2><span>04 / 06</span>
+    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/50 tracking-widest">
+      <h2 class="font-mono text-xs text-white/50 tracking-widest">// EXPERIENCE</h2><span>04 / 06</span>
     </div>
     <ol id="experience-list" class="list-none p-0 m-0 flex flex-col divide-y divide-[#1e1e1e]">
       {experiences.map((exp) => (
         <li class="list-none">
           <article class="experience-item py-8">
             <h3 class="font-mono text-sm font-bold text-white mb-1 tracking-tight">{exp.title}</h3>
-            <p class="font-mono text-xs text-white/25 tracking-widest uppercase mb-3">
+            <p class="font-mono text-xs text-white/50 tracking-widest uppercase mb-3">
               {exp.company} · {exp.period}
             </p>
             <p class="text-sm text-white/50 leading-relaxed">{exp.description}</p>

--- a/src/components/Faq.astro
+++ b/src/components/Faq.astro
@@ -25,8 +25,8 @@ const faqs = [
 
 <section id="faq" aria-label="FAQ" class="py-24 px-6 border-t border-[#1e1e1e]">
   <div class="max-w-6xl mx-auto">
-    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
-      <h2 class="font-mono text-xs text-white/25 tracking-widest">// FAQ</h2><span>05 / 06</span>
+    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/50 tracking-widest">
+      <h2 class="font-mono text-xs text-white/50 tracking-widest">// FAQ</h2><span>05 / 06</span>
     </div>
     <dl class="flex flex-col divide-y divide-[#1e1e1e]">
       {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const year = new Date().getFullYear();
 
 <footer class="py-8 px-6 border-t border-[#1e1e1e]">
   <div class="max-w-6xl mx-auto flex justify-between items-center">
-    <span class="font-mono text-[0.55rem] text-white/20 tracking-widest uppercase">
+    <span class="font-mono text-[0.55rem] text-white/50 tracking-widest uppercase">
       © {year} {config.name.toUpperCase()}
     </span>
     <a
@@ -14,7 +14,7 @@ const year = new Date().getFullYear();
       target="_blank"
       rel="noopener noreferrer"
       aria-label="View source code on GitHub"
-      class="font-mono text-[0.55rem] text-white/20 hover:text-white/40 tracking-widest uppercase transition-colors"
+      class="font-mono text-[0.55rem] text-white/50 hover:text-white/70 tracking-widest uppercase transition-colors"
     >
       DESIGNED &amp; BUILT BY RAIGATO
     </a>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -48,14 +48,14 @@ const colorData = JSON.stringify(colorRows);
         class="block"
         aria-label="ASCII portrait of Gabriel Raymondou"></canvas>
       <script is:inline type="application/json" id="ascii-colors" set:html={colorData} />
-      <div class="flex gap-4 mt-2 hidden md:flex">
-        <p class="font-mono text-[10px] text-white/20 tracking-widest">[ HOVER ]</p>
-        <p class="font-mono text-[10px] text-white/20 tracking-widest">[ CLICK ]</p>
+      <div class="flex gap-4 mt-2 hidden md:flex" aria-hidden="true">
+        <p class="font-mono text-[10px] text-white/50 tracking-widest">[ HOVER ]</p>
+        <p class="font-mono text-[10px] text-white/50 tracking-widest">[ CLICK ]</p>
       </div>
     </div>
     <!-- Terminal Typewriter -->
     <div class="terminal font-mono order-1 md:order-2 min-h-[220px]">
-      <p class="text-white/30 text-sm mb-4">~/raigato $</p>
+      <p class="text-white/50 text-sm mb-4">~/raigato $</p>
       <div id="terminal-lines" class="space-y-1 text-sm">
         <!-- Lines injected by GSAP -->
         <noscript>
@@ -122,7 +122,7 @@ const colorData = JSON.stringify(colorRows);
   }): Promise<void> {
     return new Promise((resolve) => {
       const el = document.createElement("div");
-      el.innerHTML = `<span class="text-white/40">${line.key}</span> → <span style="color:${line.color || "inherit"}"></span><span class="cursor" style="animation: blink 1s infinite; opacity:1">_</span>`;
+      el.innerHTML = `<span class="text-white/60">${line.key}</span> → <span style="color:${line.color || "inherit"}"></span><span class="cursor" style="animation: blink 1s infinite; opacity:1">_</span>`;
       terminalLines.appendChild(el);
 
       const valSpan = el.querySelectorAll("span")[1] as HTMLElement;

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,6 +3,7 @@
 
 <nav
   id="navbar"
+  aria-label="Main"
   class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 transition-all duration-300"
   style="background: transparent;"
 >

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -18,17 +18,17 @@ const { project } = Astro.props;
       <p class="text-sm text-white/50 leading-relaxed">{project.description}</p>
     </div>
     <div class="mt-4 flex flex-col md:flex-row md:justify-between md:items-end gap-4">
-      <div class="flex gap-1.5 flex-wrap">
+      <ul class="flex gap-1.5 flex-wrap list-none p-0 m-0">
         {project.tags.map((tag) => (
-          <span class="font-mono text-xs border border-[#242424] text-white/30 px-2 py-0.5 tracking-wide">{tag}</span>
+          <li class="font-mono text-xs border border-[#242424] text-white/30 px-2 py-0.5 tracking-wide">{tag}</li>
         ))}
-      </div>
+      </ul>
       <div class="flex gap-3 items-center">
         {project.github && (
-          <a href={project.github} class="font-mono text-xs text-white/30 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer">GH ↗</a>
+          <a href={project.github} class="font-mono text-xs text-white/30 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer" aria-label={`View ${project.title} on GitHub`}>GH ↗</a>
         )}
         {project.url && (
-          <a href={project.url} class="font-mono text-xs text-white/30 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer">LIVE ↗</a>
+          <a href={project.url} class="font-mono text-xs text-white/30 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer" aria-label={`View ${project.title} live`}>LIVE ↗</a>
         )}
       </div>
     </div>

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -13,22 +13,22 @@ const { project } = Astro.props;
 >
   <div class="p-4 flex flex-col justify-between overflow-hidden">
     <div>
-      <p class="font-mono text-xs text-white/25 mb-1">{project.number} —</p>
+      <p class="font-mono text-xs text-white/50 mb-1">{project.number} —</p>
       <h3 class="font-mono text-base font-bold text-white mb-2 tracking-tight">{project.title}</h3>
       <p class="text-sm text-white/50 leading-relaxed">{project.description}</p>
     </div>
     <div class="mt-4 flex flex-col md:flex-row md:justify-between md:items-end gap-4">
       <ul class="flex gap-1.5 flex-wrap list-none p-0 m-0">
         {project.tags.map((tag) => (
-          <li class="font-mono text-xs border border-[#242424] text-white/30 px-2 py-0.5 tracking-wide">{tag}</li>
+          <li class="font-mono text-xs border border-[#242424] text-white/50 px-2 py-0.5 tracking-wide">{tag}</li>
         ))}
       </ul>
       <div class="flex gap-3 items-center">
         {project.github && (
-          <a href={project.github} class="font-mono text-xs text-white/30 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer" aria-label={`View ${project.title} on GitHub`}>GH ↗</a>
+          <a href={project.github} class="font-mono text-xs text-white/50 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer" aria-label={`View ${project.title} on GitHub`}>GH ↗</a>
         )}
         {project.url && (
-          <a href={project.url} class="font-mono text-xs text-white/30 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer" aria-label={`View ${project.title} live`}>LIVE ↗</a>
+          <a href={project.url} class="font-mono text-xs text-white/50 hover:text-white/70 transition-colors duration-200" target="_blank" rel="noopener noreferrer" aria-label={`View ${project.title} live`}>LIVE ↗</a>
         )}
       </div>
     </div>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -8,11 +8,13 @@ import ProjectCard from "./ProjectCard.astro";
     <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
       <h2 class="font-mono text-xs text-white/25 tracking-widest">// SELECTED WORK</h2><span>03 / 06</span>
     </div>
-    <div id="projects-list">
+    <ul id="projects-list" class="list-none p-0 m-0">
       {projects.map((project) => (
-        <ProjectCard project={project} />
+        <li class="list-none">
+          <ProjectCard project={project} />
+        </li>
       ))}
-    </div>
+    </ul>
   </div>
 </section>
 

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -5,8 +5,8 @@ import ProjectCard from "./ProjectCard.astro";
 
 <section id="projects" aria-label="Selected Work" class="py-24 px-6 border-t border-[#1e1e1e]">
   <div class="max-w-6xl mx-auto">
-    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/25 tracking-widest">
-      <h2 class="font-mono text-xs text-white/25 tracking-widest">// SELECTED WORK</h2><span>03 / 06</span>
+    <div class="flex justify-between items-center mb-12 font-mono text-xs text-white/50 tracking-widest">
+      <h2 class="font-mono text-xs text-white/50 tracking-widest">// SELECTED WORK</h2><span>03 / 06</span>
     </div>
     <ul id="projects-list" class="list-none p-0 m-0">
       {projects.map((project) => (


### PR DESCRIPTION
## Summary

### Semantic HTML
- Convert `div#projects-list` → `ul` + `li` wrappers (`Projects.astro`)
- Convert `div#experience-list` → `ol` + `li` wrappers (`Experience.astro`)
- Convert tech stack grid `div` + `span` → `ul` + `li` (`About.astro`)
- Convert project tags `div` + `span` → `ul` + `li` (`ProjectCard.astro`)
- Add descriptive `aria-label` to "GH ↗" / "LIVE ↗" external links (`ProjectCard.astro`)
- Add `aria-hidden="true"` to decorative cursor elements (`Cursor.astro`)
- Add `aria-label="Main"` to `<nav>` (`Navbar.astro`)

### WCAG AA Color Contrast
- Bump all low-contrast text to meet the 4.5:1 minimum ratio (`text-white/50+`)
- Affected: section headers, project numbers/tags/links, experience metadata, footer, hero terminal

### Playwright + axe-core Audit
- Add `e2e/accessibility.spec.ts` — full-page axe scan via `@axe-core/playwright`
- Add `playwright.config.ts` with Chromium + auto dev server
- Hook into `pre-push` via Husky to block pushes with violations
- Add `e2e` CI job in `deploy.yml` — runs in parallel with build, blocks deploy on failure