### PR TITLE
fix: prevent navbar from wrapping to 2 lines on mobile

### DIFF
--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -4,24 +4,25 @@
 <nav
   id="navbar"
   aria-label="Main"
-  class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-6 py-4 transition-all duration-300"
+  class="fixed top-0 left-0 right-0 z-50 flex items-center justify-between px-3 sm:px-6 py-4 transition-all duration-300"
   style="background: transparent;"
 >
   <span class="font-mono text-sm tracking-widest text-white/60">Raigato<span aria-hidden="true"> —</span></span>
-  <div class="flex items-center gap-3">
+  <div class="flex items-center gap-2 sm:gap-3">
     <button
       id="theme-toggle"
       aria-label="Toggle theme"
-      class="font-mono text-xs tracking-widest px-2 py-1 transition-colors duration-200"
+      class="font-mono text-xs tracking-widest px-1 sm:px-2 py-1 transition-colors duration-200"
       style="color: var(--fg);"
     >
       [dark_mode]
     </button>
     <a
       href="#contact"
-      class="font-mono text-xs tracking-widest bg-white text-black px-4 py-2 hover:bg-white/85 transition-all duration-200 uppercase"
+      class="font-mono text-xs tracking-widest bg-white text-black px-2 sm:px-4 py-2 hover:bg-white/85 transition-all duration-200 uppercase whitespace-nowrap"
     >
-      GET IN TOUCH →
+      <span class="sm:hidden">CONTACT →</span>
+      <span class="hidden sm:inline">GET IN TOUCH →</span>
     </a>
   </div>
 </nav>


### PR DESCRIPTION
## Summary
- Reduce nav horizontal padding from `px-6` to `px-3 sm:px-6` on mobile
- Tighten right-side flex gap and toggle/CTA button padding at small viewports
- Shorten CTA text to "CONTACT →" on mobile (full "GET IN TOUCH →" on sm+)
- Fixes single-line navbar on 375px+ screens (iPhone SE and up)