### PR TITLE
fix: prevent scroll jump and horizontal overflow on theme transition

### DIFF
--- a/src/components/ThemeTransition.astro
+++ b/src/components/ThemeTransition.astro
@@ -14,13 +14,15 @@
       return
     }
 
+    const savedScrollY = window.scrollY
+
     const selectors = 'h1, h2, h3, h4, nav a, button, .font-mono'
     const targets = [...document.querySelectorAll<HTMLElement>(selectors)].filter((el) => {
-      const text = el.textContent?.trim() ?? ''
+      const text = el.innerText?.trim() ?? ''
       return text.length > 0 && text.length <= 60 && !el.querySelector(selectors)
     })
 
-    const originals = targets.map((el) => el.textContent ?? '')
+    const originals = targets.map((el) => el.innerText ?? '')
     const originalHTMLs = targets.map((el) => el.innerHTML)
     let frame = 0
     const totalFrames = 20
@@ -59,6 +61,7 @@
         targets.forEach((el, i) => {
           el.innerHTML = originalHTMLs[i]
         })
+        window.scrollTo({ top: savedScrollY, behavior: 'instant' })
         window.dispatchEvent(new CustomEvent('theme-transition-complete'))
       }
     }, 30)


### PR DESCRIPTION
## Summary
- Save `window.scrollY` before the scramble animation starts and restore it with `behavior: 'instant'` at the end, preventing mobile browsers from scrolling when anchor `innerHTML` is restored
- Switch `textContent` reads to `innerText` so the scramble only operates on visually rendered text — fixes horizontal overflow caused by the responsive CTA spans (`sm:hidden` / `hidden sm:inline`) both being included in the scramble string regardless of CSS visibility